### PR TITLE
feat(aggregation-svc): expose supported fiat currencies API

### DIFF
--- a/api/proto/aggregation/v1/aggregation.proto
+++ b/api/proto/aggregation/v1/aggregation.proto
@@ -45,6 +45,14 @@ service Aggregation {
       body: "*"
     };
   }
+
+  // ListSupportedFiatCurrencies returns fiat codes supported by valuation pipeline.
+  rpc ListSupportedFiatCurrencies(ListSupportedFiatCurrenciesRequest)
+  returns (ListSupportedFiatCurrenciesResponse) {
+    option (google.api.http) = {
+      get: "/v1/fiat-currencies"
+    };
+  }
 }
 
 message AggregatedTx {
@@ -117,4 +125,15 @@ message UpsertTenantSettingsRequest {
 
 message UpsertTenantSettingsResponse {
   TenantSettings settings = 1;
+}
+
+message SupportedFiatCurrency {
+  string code = 1;
+  string display_name = 2;
+}
+
+message ListSupportedFiatCurrenciesRequest {}
+
+message ListSupportedFiatCurrenciesResponse {
+  repeated SupportedFiatCurrency currencies = 1;
 }

--- a/gen/aggregation/v1/aggregation.pb.go
+++ b/gen/aggregation/v1/aggregation.pb.go
@@ -699,6 +699,138 @@ func (x *UpsertTenantSettingsResponse) GetSettings() *TenantSettings {
 	return nil
 }
 
+type SupportedFiatCurrency struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Code          string                 `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SupportedFiatCurrency) Reset() {
+	*x = SupportedFiatCurrency{}
+	mi := &file_aggregation_v1_aggregation_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SupportedFiatCurrency) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SupportedFiatCurrency) ProtoMessage() {}
+
+func (x *SupportedFiatCurrency) ProtoReflect() protoreflect.Message {
+	mi := &file_aggregation_v1_aggregation_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SupportedFiatCurrency.ProtoReflect.Descriptor instead.
+func (*SupportedFiatCurrency) Descriptor() ([]byte, []int) {
+	return file_aggregation_v1_aggregation_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *SupportedFiatCurrency) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *SupportedFiatCurrency) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+type ListSupportedFiatCurrenciesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSupportedFiatCurrenciesRequest) Reset() {
+	*x = ListSupportedFiatCurrenciesRequest{}
+	mi := &file_aggregation_v1_aggregation_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSupportedFiatCurrenciesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSupportedFiatCurrenciesRequest) ProtoMessage() {}
+
+func (x *ListSupportedFiatCurrenciesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_aggregation_v1_aggregation_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSupportedFiatCurrenciesRequest.ProtoReflect.Descriptor instead.
+func (*ListSupportedFiatCurrenciesRequest) Descriptor() ([]byte, []int) {
+	return file_aggregation_v1_aggregation_proto_rawDescGZIP(), []int{11}
+}
+
+type ListSupportedFiatCurrenciesResponse struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Currencies    []*SupportedFiatCurrency `protobuf:"bytes,1,rep,name=currencies,proto3" json:"currencies,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSupportedFiatCurrenciesResponse) Reset() {
+	*x = ListSupportedFiatCurrenciesResponse{}
+	mi := &file_aggregation_v1_aggregation_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSupportedFiatCurrenciesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSupportedFiatCurrenciesResponse) ProtoMessage() {}
+
+func (x *ListSupportedFiatCurrenciesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_aggregation_v1_aggregation_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSupportedFiatCurrenciesResponse.ProtoReflect.Descriptor instead.
+func (*ListSupportedFiatCurrenciesResponse) Descriptor() ([]byte, []int) {
+	return file_aggregation_v1_aggregation_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ListSupportedFiatCurrenciesResponse) GetCurrencies() []*SupportedFiatCurrency {
+	if x != nil {
+		return x.Currencies
+	}
+	return nil
+}
+
 var File_aggregation_v1_aggregation_proto protoreflect.FileDescriptor
 
 const file_aggregation_v1_aggregation_proto_rawDesc = "" +
@@ -760,12 +892,21 @@ const file_aggregation_v1_aggregation_proto_rawDesc = "" +
 	"\rfiat_currency\x18\x02 \x01(\tR\ffiatCurrency\x12\x1a\n" +
 	"\btimezone\x18\x03 \x01(\tR\btimezone\"Z\n" +
 	"\x1cUpsertTenantSettingsResponse\x12:\n" +
-	"\bsettings\x18\x01 \x01(\v2\x1e.aggregation.v1.TenantSettingsR\bsettings2\xb0\x05\n" +
+	"\bsettings\x18\x01 \x01(\v2\x1e.aggregation.v1.TenantSettingsR\bsettings\"N\n" +
+	"\x15SupportedFiatCurrency\x12\x12\n" +
+	"\x04code\x18\x01 \x01(\tR\x04code\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\"$\n" +
+	"\"ListSupportedFiatCurrenciesRequest\"l\n" +
+	"#ListSupportedFiatCurrenciesResponse\x12E\n" +
+	"\n" +
+	"currencies\x18\x01 \x03(\v2%.aggregation.v1.SupportedFiatCurrencyR\n" +
+	"currencies2\xd6\x06\n" +
 	"\vAggregation\x12\xbf\x01\n" +
 	"\x18ListTransactionsByImport\x12/.aggregation.v1.ListTransactionsByImportRequest\x1a0.aggregation.v1.ListTransactionsByImportResponse\"@\x82\xd3\xe4\x93\x02:\x128/v1/tenants/{tenant_id}/imports/{import_id}/transactions\x12\xa8\x01\n" +
 	"\x17ListTransactionsByRange\x12..aggregation.v1.ListTransactionsByRangeRequest\x1a/.aggregation.v1.ListTransactionsByRangeResponse\",\x82\xd3\xe4\x93\x02&\x12$/v1/tenants/{tenant_id}/transactions\x12\x92\x01\n" +
 	"\x11GetTenantSettings\x12(.aggregation.v1.GetTenantSettingsRequest\x1a).aggregation.v1.GetTenantSettingsResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /v1/tenants/{tenant_id}/settings\x12\x9e\x01\n" +
-	"\x14UpsertTenantSettings\x12+.aggregation.v1.UpsertTenantSettingsRequest\x1a,.aggregation.v1.UpsertTenantSettingsResponse\"+\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/tenants/{tenant_id}/settingsBFZDgithub.com/NightRunner/CryptoTax-Go/gen/aggregation/v1;aggregationv1b\x06proto3"
+	"\x14UpsertTenantSettings\x12+.aggregation.v1.UpsertTenantSettingsRequest\x1a,.aggregation.v1.UpsertTenantSettingsResponse\"+\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/tenants/{tenant_id}/settings\x12\xa3\x01\n" +
+	"\x1bListSupportedFiatCurrencies\x122.aggregation.v1.ListSupportedFiatCurrenciesRequest\x1a3.aggregation.v1.ListSupportedFiatCurrenciesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/fiat-currenciesBFZDgithub.com/NightRunner/CryptoTax-Go/gen/aggregation/v1;aggregationv1b\x06proto3"
 
 var (
 	file_aggregation_v1_aggregation_proto_rawDescOnce sync.Once
@@ -779,45 +920,51 @@ func file_aggregation_v1_aggregation_proto_rawDescGZIP() []byte {
 	return file_aggregation_v1_aggregation_proto_rawDescData
 }
 
-var file_aggregation_v1_aggregation_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_aggregation_v1_aggregation_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_aggregation_v1_aggregation_proto_goTypes = []any{
-	(*AggregatedTx)(nil),                     // 0: aggregation.v1.AggregatedTx
-	(*ListTransactionsByImportRequest)(nil),  // 1: aggregation.v1.ListTransactionsByImportRequest
-	(*ListTransactionsByImportResponse)(nil), // 2: aggregation.v1.ListTransactionsByImportResponse
-	(*ListTransactionsByRangeRequest)(nil),   // 3: aggregation.v1.ListTransactionsByRangeRequest
-	(*ListTransactionsByRangeResponse)(nil),  // 4: aggregation.v1.ListTransactionsByRangeResponse
-	(*TenantSettings)(nil),                   // 5: aggregation.v1.TenantSettings
-	(*GetTenantSettingsRequest)(nil),         // 6: aggregation.v1.GetTenantSettingsRequest
-	(*GetTenantSettingsResponse)(nil),        // 7: aggregation.v1.GetTenantSettingsResponse
-	(*UpsertTenantSettingsRequest)(nil),      // 8: aggregation.v1.UpsertTenantSettingsRequest
-	(*UpsertTenantSettingsResponse)(nil),     // 9: aggregation.v1.UpsertTenantSettingsResponse
-	(*timestamppb.Timestamp)(nil),            // 10: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                  // 11: google.protobuf.Struct
+	(*AggregatedTx)(nil),                        // 0: aggregation.v1.AggregatedTx
+	(*ListTransactionsByImportRequest)(nil),     // 1: aggregation.v1.ListTransactionsByImportRequest
+	(*ListTransactionsByImportResponse)(nil),    // 2: aggregation.v1.ListTransactionsByImportResponse
+	(*ListTransactionsByRangeRequest)(nil),      // 3: aggregation.v1.ListTransactionsByRangeRequest
+	(*ListTransactionsByRangeResponse)(nil),     // 4: aggregation.v1.ListTransactionsByRangeResponse
+	(*TenantSettings)(nil),                      // 5: aggregation.v1.TenantSettings
+	(*GetTenantSettingsRequest)(nil),            // 6: aggregation.v1.GetTenantSettingsRequest
+	(*GetTenantSettingsResponse)(nil),           // 7: aggregation.v1.GetTenantSettingsResponse
+	(*UpsertTenantSettingsRequest)(nil),         // 8: aggregation.v1.UpsertTenantSettingsRequest
+	(*UpsertTenantSettingsResponse)(nil),        // 9: aggregation.v1.UpsertTenantSettingsResponse
+	(*SupportedFiatCurrency)(nil),               // 10: aggregation.v1.SupportedFiatCurrency
+	(*ListSupportedFiatCurrenciesRequest)(nil),  // 11: aggregation.v1.ListSupportedFiatCurrenciesRequest
+	(*ListSupportedFiatCurrenciesResponse)(nil), // 12: aggregation.v1.ListSupportedFiatCurrenciesResponse
+	(*timestamppb.Timestamp)(nil),               // 13: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                     // 14: google.protobuf.Struct
 }
 var file_aggregation_v1_aggregation_proto_depIdxs = []int32{
-	10, // 0: aggregation.v1.AggregatedTx.time_utc:type_name -> google.protobuf.Timestamp
-	11, // 1: aggregation.v1.AggregatedTx.in_money:type_name -> google.protobuf.Struct
-	11, // 2: aggregation.v1.AggregatedTx.out_money:type_name -> google.protobuf.Struct
-	11, // 3: aggregation.v1.AggregatedTx.fee_money:type_name -> google.protobuf.Struct
+	13, // 0: aggregation.v1.AggregatedTx.time_utc:type_name -> google.protobuf.Timestamp
+	14, // 1: aggregation.v1.AggregatedTx.in_money:type_name -> google.protobuf.Struct
+	14, // 2: aggregation.v1.AggregatedTx.out_money:type_name -> google.protobuf.Struct
+	14, // 3: aggregation.v1.AggregatedTx.fee_money:type_name -> google.protobuf.Struct
 	0,  // 4: aggregation.v1.ListTransactionsByImportResponse.transactions:type_name -> aggregation.v1.AggregatedTx
-	10, // 5: aggregation.v1.ListTransactionsByRangeRequest.from_utc:type_name -> google.protobuf.Timestamp
-	10, // 6: aggregation.v1.ListTransactionsByRangeRequest.to_utc:type_name -> google.protobuf.Timestamp
+	13, // 5: aggregation.v1.ListTransactionsByRangeRequest.from_utc:type_name -> google.protobuf.Timestamp
+	13, // 6: aggregation.v1.ListTransactionsByRangeRequest.to_utc:type_name -> google.protobuf.Timestamp
 	0,  // 7: aggregation.v1.ListTransactionsByRangeResponse.transactions:type_name -> aggregation.v1.AggregatedTx
 	5,  // 8: aggregation.v1.GetTenantSettingsResponse.settings:type_name -> aggregation.v1.TenantSettings
 	5,  // 9: aggregation.v1.UpsertTenantSettingsResponse.settings:type_name -> aggregation.v1.TenantSettings
-	1,  // 10: aggregation.v1.Aggregation.ListTransactionsByImport:input_type -> aggregation.v1.ListTransactionsByImportRequest
-	3,  // 11: aggregation.v1.Aggregation.ListTransactionsByRange:input_type -> aggregation.v1.ListTransactionsByRangeRequest
-	6,  // 12: aggregation.v1.Aggregation.GetTenantSettings:input_type -> aggregation.v1.GetTenantSettingsRequest
-	8,  // 13: aggregation.v1.Aggregation.UpsertTenantSettings:input_type -> aggregation.v1.UpsertTenantSettingsRequest
-	2,  // 14: aggregation.v1.Aggregation.ListTransactionsByImport:output_type -> aggregation.v1.ListTransactionsByImportResponse
-	4,  // 15: aggregation.v1.Aggregation.ListTransactionsByRange:output_type -> aggregation.v1.ListTransactionsByRangeResponse
-	7,  // 16: aggregation.v1.Aggregation.GetTenantSettings:output_type -> aggregation.v1.GetTenantSettingsResponse
-	9,  // 17: aggregation.v1.Aggregation.UpsertTenantSettings:output_type -> aggregation.v1.UpsertTenantSettingsResponse
-	14, // [14:18] is the sub-list for method output_type
-	10, // [10:14] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	10, // 10: aggregation.v1.ListSupportedFiatCurrenciesResponse.currencies:type_name -> aggregation.v1.SupportedFiatCurrency
+	1,  // 11: aggregation.v1.Aggregation.ListTransactionsByImport:input_type -> aggregation.v1.ListTransactionsByImportRequest
+	3,  // 12: aggregation.v1.Aggregation.ListTransactionsByRange:input_type -> aggregation.v1.ListTransactionsByRangeRequest
+	6,  // 13: aggregation.v1.Aggregation.GetTenantSettings:input_type -> aggregation.v1.GetTenantSettingsRequest
+	8,  // 14: aggregation.v1.Aggregation.UpsertTenantSettings:input_type -> aggregation.v1.UpsertTenantSettingsRequest
+	11, // 15: aggregation.v1.Aggregation.ListSupportedFiatCurrencies:input_type -> aggregation.v1.ListSupportedFiatCurrenciesRequest
+	2,  // 16: aggregation.v1.Aggregation.ListTransactionsByImport:output_type -> aggregation.v1.ListTransactionsByImportResponse
+	4,  // 17: aggregation.v1.Aggregation.ListTransactionsByRange:output_type -> aggregation.v1.ListTransactionsByRangeResponse
+	7,  // 18: aggregation.v1.Aggregation.GetTenantSettings:output_type -> aggregation.v1.GetTenantSettingsResponse
+	9,  // 19: aggregation.v1.Aggregation.UpsertTenantSettings:output_type -> aggregation.v1.UpsertTenantSettingsResponse
+	12, // 20: aggregation.v1.Aggregation.ListSupportedFiatCurrencies:output_type -> aggregation.v1.ListSupportedFiatCurrenciesResponse
+	16, // [16:21] is the sub-list for method output_type
+	11, // [11:16] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_aggregation_v1_aggregation_proto_init() }
@@ -832,7 +979,7 @@ func file_aggregation_v1_aggregation_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_aggregation_v1_aggregation_proto_rawDesc), len(file_aggregation_v1_aggregation_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/aggregation/v1/aggregation.pb.gw.go
+++ b/gen/aggregation/v1/aggregation.pb.gw.go
@@ -241,6 +241,27 @@ func local_request_Aggregation_UpsertTenantSettings_0(ctx context.Context, marsh
 	return msg, metadata, err
 }
 
+func request_Aggregation_ListSupportedFiatCurrencies_0(ctx context.Context, marshaler runtime.Marshaler, client AggregationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListSupportedFiatCurrenciesRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListSupportedFiatCurrencies(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_Aggregation_ListSupportedFiatCurrencies_0(ctx context.Context, marshaler runtime.Marshaler, server AggregationServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListSupportedFiatCurrenciesRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListSupportedFiatCurrencies(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterAggregationHandlerServer registers the http handlers for service Aggregation to "mux".
 // UnaryRPC     :call AggregationServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -326,6 +347,26 @@ func RegisterAggregationHandlerServer(ctx context.Context, mux *runtime.ServeMux
 			return
 		}
 		forward_Aggregation_UpsertTenantSettings_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_Aggregation_ListSupportedFiatCurrencies_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/aggregation.v1.Aggregation/ListSupportedFiatCurrencies", runtime.WithHTTPPathPattern("/v1/fiat-currencies"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Aggregation_ListSupportedFiatCurrencies_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Aggregation_ListSupportedFiatCurrencies_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -435,19 +476,38 @@ func RegisterAggregationHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_Aggregation_UpsertTenantSettings_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_Aggregation_ListSupportedFiatCurrencies_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/aggregation.v1.Aggregation/ListSupportedFiatCurrencies", runtime.WithHTTPPathPattern("/v1/fiat-currencies"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Aggregation_ListSupportedFiatCurrencies_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Aggregation_ListSupportedFiatCurrencies_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_Aggregation_ListTransactionsByImport_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"v1", "tenants", "tenant_id", "imports", "import_id", "transactions"}, ""))
-	pattern_Aggregation_ListTransactionsByRange_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "transactions"}, ""))
-	pattern_Aggregation_GetTenantSettings_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "settings"}, ""))
-	pattern_Aggregation_UpsertTenantSettings_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "settings"}, ""))
+	pattern_Aggregation_ListTransactionsByImport_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"v1", "tenants", "tenant_id", "imports", "import_id", "transactions"}, ""))
+	pattern_Aggregation_ListTransactionsByRange_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "transactions"}, ""))
+	pattern_Aggregation_GetTenantSettings_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "settings"}, ""))
+	pattern_Aggregation_UpsertTenantSettings_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "settings"}, ""))
+	pattern_Aggregation_ListSupportedFiatCurrencies_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "fiat-currencies"}, ""))
 )
 
 var (
-	forward_Aggregation_ListTransactionsByImport_0 = runtime.ForwardResponseMessage
-	forward_Aggregation_ListTransactionsByRange_0  = runtime.ForwardResponseMessage
-	forward_Aggregation_GetTenantSettings_0        = runtime.ForwardResponseMessage
-	forward_Aggregation_UpsertTenantSettings_0     = runtime.ForwardResponseMessage
+	forward_Aggregation_ListTransactionsByImport_0    = runtime.ForwardResponseMessage
+	forward_Aggregation_ListTransactionsByRange_0     = runtime.ForwardResponseMessage
+	forward_Aggregation_GetTenantSettings_0           = runtime.ForwardResponseMessage
+	forward_Aggregation_UpsertTenantSettings_0        = runtime.ForwardResponseMessage
+	forward_Aggregation_ListSupportedFiatCurrencies_0 = runtime.ForwardResponseMessage
 )

--- a/gen/aggregation/v1/aggregation_grpc.pb.go
+++ b/gen/aggregation/v1/aggregation_grpc.pb.go
@@ -19,10 +19,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Aggregation_ListTransactionsByImport_FullMethodName = "/aggregation.v1.Aggregation/ListTransactionsByImport"
-	Aggregation_ListTransactionsByRange_FullMethodName  = "/aggregation.v1.Aggregation/ListTransactionsByRange"
-	Aggregation_GetTenantSettings_FullMethodName        = "/aggregation.v1.Aggregation/GetTenantSettings"
-	Aggregation_UpsertTenantSettings_FullMethodName     = "/aggregation.v1.Aggregation/UpsertTenantSettings"
+	Aggregation_ListTransactionsByImport_FullMethodName    = "/aggregation.v1.Aggregation/ListTransactionsByImport"
+	Aggregation_ListTransactionsByRange_FullMethodName     = "/aggregation.v1.Aggregation/ListTransactionsByRange"
+	Aggregation_GetTenantSettings_FullMethodName           = "/aggregation.v1.Aggregation/GetTenantSettings"
+	Aggregation_UpsertTenantSettings_FullMethodName        = "/aggregation.v1.Aggregation/UpsertTenantSettings"
+	Aggregation_ListSupportedFiatCurrencies_FullMethodName = "/aggregation.v1.Aggregation/ListSupportedFiatCurrencies"
 )
 
 // AggregationClient is the client API for Aggregation service.
@@ -42,6 +43,8 @@ type AggregationClient interface {
 	GetTenantSettings(ctx context.Context, in *GetTenantSettingsRequest, opts ...grpc.CallOption) (*GetTenantSettingsResponse, error)
 	// UpsertTenantSettings creates or updates aggregation settings for a tenant.
 	UpsertTenantSettings(ctx context.Context, in *UpsertTenantSettingsRequest, opts ...grpc.CallOption) (*UpsertTenantSettingsResponse, error)
+	// ListSupportedFiatCurrencies returns fiat codes supported by valuation pipeline.
+	ListSupportedFiatCurrencies(ctx context.Context, in *ListSupportedFiatCurrenciesRequest, opts ...grpc.CallOption) (*ListSupportedFiatCurrenciesResponse, error)
 }
 
 type aggregationClient struct {
@@ -92,6 +95,16 @@ func (c *aggregationClient) UpsertTenantSettings(ctx context.Context, in *Upsert
 	return out, nil
 }
 
+func (c *aggregationClient) ListSupportedFiatCurrencies(ctx context.Context, in *ListSupportedFiatCurrenciesRequest, opts ...grpc.CallOption) (*ListSupportedFiatCurrenciesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSupportedFiatCurrenciesResponse)
+	err := c.cc.Invoke(ctx, Aggregation_ListSupportedFiatCurrencies_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AggregationServer is the server API for Aggregation service.
 // All implementations must embed UnimplementedAggregationServer
 // for forward compatibility.
@@ -109,6 +122,8 @@ type AggregationServer interface {
 	GetTenantSettings(context.Context, *GetTenantSettingsRequest) (*GetTenantSettingsResponse, error)
 	// UpsertTenantSettings creates or updates aggregation settings for a tenant.
 	UpsertTenantSettings(context.Context, *UpsertTenantSettingsRequest) (*UpsertTenantSettingsResponse, error)
+	// ListSupportedFiatCurrencies returns fiat codes supported by valuation pipeline.
+	ListSupportedFiatCurrencies(context.Context, *ListSupportedFiatCurrenciesRequest) (*ListSupportedFiatCurrenciesResponse, error)
 	mustEmbedUnimplementedAggregationServer()
 }
 
@@ -130,6 +145,9 @@ func (UnimplementedAggregationServer) GetTenantSettings(context.Context, *GetTen
 }
 func (UnimplementedAggregationServer) UpsertTenantSettings(context.Context, *UpsertTenantSettingsRequest) (*UpsertTenantSettingsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpsertTenantSettings not implemented")
+}
+func (UnimplementedAggregationServer) ListSupportedFiatCurrencies(context.Context, *ListSupportedFiatCurrenciesRequest) (*ListSupportedFiatCurrenciesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSupportedFiatCurrencies not implemented")
 }
 func (UnimplementedAggregationServer) mustEmbedUnimplementedAggregationServer() {}
 func (UnimplementedAggregationServer) testEmbeddedByValue()                     {}
@@ -224,6 +242,24 @@ func _Aggregation_UpsertTenantSettings_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Aggregation_ListSupportedFiatCurrencies_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSupportedFiatCurrenciesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AggregationServer).ListSupportedFiatCurrencies(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Aggregation_ListSupportedFiatCurrencies_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AggregationServer).ListSupportedFiatCurrencies(ctx, req.(*ListSupportedFiatCurrenciesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Aggregation_ServiceDesc is the grpc.ServiceDesc for Aggregation service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -246,6 +282,10 @@ var Aggregation_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpsertTenantSettings",
 			Handler:    _Aggregation_UpsertTenantSettings_Handler,
+		},
+		{
+			MethodName: "ListSupportedFiatCurrencies",
+			Handler:    _Aggregation_ListSupportedFiatCurrencies_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/services/aggregation-svc/internal/domain/interfaces.go
+++ b/services/aggregation-svc/internal/domain/interfaces.go
@@ -23,6 +23,7 @@ type AggregationUseCase interface {
 type TenantSettingsUseCase interface {
 	Get(ctx context.Context, tenantID uuid.UUID) (TenantSettings, error)
 	Upsert(ctx context.Context, settings TenantSettings) (TenantSettings, error)
+	ListSupportedFiatCurrencies(ctx context.Context) ([]SupportedFiatCurrency, error)
 }
 
 type AggregatedTransactionRepo interface {

--- a/services/aggregation-svc/internal/domain/tenant_settings.go
+++ b/services/aggregation-svc/internal/domain/tenant_settings.go
@@ -12,3 +12,8 @@ type TenantSettings struct {
 	Timezone     string    `json:"timezone"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
+
+type SupportedFiatCurrency struct {
+	Code        string `json:"code"`
+	DisplayName string `json:"display_name"`
+}

--- a/services/aggregation-svc/internal/server/server.go
+++ b/services/aggregation-svc/internal/server/server.go
@@ -340,6 +340,45 @@ func (s *AggregationServer) UpsertTenantSettings(ctx context.Context, req *aggre
 	}, nil
 }
 
+func (s *AggregationServer) ListSupportedFiatCurrencies(
+	ctx context.Context,
+	req *aggregationv1.ListSupportedFiatCurrenciesRequest,
+) (*aggregationv1.ListSupportedFiatCurrenciesResponse, error) {
+	log := logger.FromContext(ctx)
+	if req == nil {
+		return nil, apperr.InvalidArgument(
+			"invalid request",
+			nil,
+			apperr.FieldViolation{Field: "request", Description: "required"},
+		)
+	}
+	if err := requireTenantHeader(ctx); err != nil {
+		return nil, err
+	}
+
+	if s.settingsUC == nil {
+		return nil, apperr.Internal("tenant settings usecase is not configured", nil, nil)
+	}
+
+	currencies, err := s.settingsUC.ListSupportedFiatCurrencies(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]*aggregationv1.SupportedFiatCurrency, 0, len(currencies))
+	for _, currency := range currencies {
+		items = append(items, &aggregationv1.SupportedFiatCurrency{
+			Code:        currency.Code,
+			DisplayName: currency.DisplayName,
+		})
+	}
+
+	log.Debug("ListSupportedFiatCurrencies: success", zap.Int("count", len(items)))
+	return &aggregationv1.ListSupportedFiatCurrenciesResponse{
+		Currencies: items,
+	}, nil
+}
+
 func parseUUID(s string) (uuid.UUID, error) {
 	id, err := uuid.Parse(s)
 	if err != nil {

--- a/services/aggregation-svc/internal/usecases/supported_fiat.go
+++ b/services/aggregation-svc/internal/usecases/supported_fiat.go
@@ -1,0 +1,26 @@
+package usecase
+
+import "github.com/NightRunner/CryptoTax-Go/services/aggregation-svc/internal/domain"
+
+var supportedFiatCurrencies = []domain.SupportedFiatCurrency{
+	{Code: "USD", DisplayName: "US Dollar"},
+	{Code: "RUB", DisplayName: "Russian Ruble"},
+	{Code: "KZT", DisplayName: "Kazakhstani Tenge"},
+}
+
+var supportedFiatSet = map[string]struct{}{
+	"USD": {},
+	"RUB": {},
+	"KZT": {},
+}
+
+func listSupportedFiatCurrencies() []domain.SupportedFiatCurrency {
+	out := make([]domain.SupportedFiatCurrency, len(supportedFiatCurrencies))
+	copy(out, supportedFiatCurrencies)
+	return out
+}
+
+func isSupportedFiatCurrency(code string) bool {
+	_, ok := supportedFiatSet[code]
+	return ok
+}

--- a/services/aggregation-svc/internal/usecases/tenant_settings_usecase.go
+++ b/services/aggregation-svc/internal/usecases/tenant_settings_usecase.go
@@ -74,6 +74,11 @@ func (u *tenantSettingsUC) Upsert(ctx context.Context, settings domain.TenantSet
 	return u.repo.Upsert(ctx, settings)
 }
 
+func (u *tenantSettingsUC) ListSupportedFiatCurrencies(ctx context.Context) ([]domain.SupportedFiatCurrency, error) {
+	_ = ctx
+	return listSupportedFiatCurrencies(), nil
+}
+
 func normalizeFiatCurrency(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -98,6 +103,16 @@ func validateTenantSettings(settings domain.TenantSettings) error {
 			apperr.FieldViolation{
 				Field:       "fiat_currency",
 				Description: "required",
+			},
+		)
+	}
+	if !isSupportedFiatCurrency(settings.FiatCurrency) {
+		return apperr.InvalidArgument(
+			"invalid fiat currency",
+			nil,
+			apperr.FieldViolation{
+				Field:       "fiat_currency",
+				Description: "unsupported value",
 			},
 		)
 	}


### PR DESCRIPTION
## Summary
Added a new `aggregation-svc` API to return supported fiat currencies for UI/settings validation.

- Added gRPC method + grpc-gateway route:
  - `ListSupportedFiatCurrencies`
  - `GET /v1/fiat-currencies`
- Introduced domain model for supported fiat metadata (`code`, `display_name`).
- Implemented deterministic supported fiat list in usecase layer (`USD`, `RUB`, `KZT`).
- Added tenant settings validation against supported fiat set (reject unsupported values).
- Regenerated protobuf/gateway stubs.

Closed #21 